### PR TITLE
Update equipment, remove weight listings.

### DIFF
--- a/src/data/armor.yml
+++ b/src/data/armor.yml
@@ -2,38 +2,38 @@
 id: armor
 columns: 2
 header:
-    - Armor | Size | Cost | Bonus | Weight
-    - :---- | :--- | :--- | :---- | :-----
+    - "**Armor** | Size | Cost | Bonus"
+    - :---- | :--- | :--- | :----
 data:
-    - Padded | Light | 2gp | +1 | 10 lbs.
-    - Leather | Light | 10gp | +2 | 15 lbs.
-    - Studded Leather | Light | 50gp | +3 | 20 lbs.
-    - Chain Shirt | Light | 100gp | +4 | 25 lbs.
-    - Hide | Medium | 30gp | +3 | 18 lbs.
-    - Scale Mail | Medium | 75gp | +4 | 30 lbs.
-    - Chainmail | Medium | 150gp | +5 | 40 lbs.
-    - Breastplate | Medium | 250gp | +6 | 30 lbs.
-    - Splint Mail | Heavy | 100gp | +5 | 45 lbs.
-    - Banded Mail | Heavy | 200gp | +6 | 35 lbs.
-    - Half-plate | Heavy | 600gp | +7 | 50 lbs.
-    - Full Plate | Heavy | 1,500gp | +8 | 50 lbs.
+    - Padded | Light | 2gp | +1
+    - Leather | Light | 10gp | +2
+    - Studded Leather | Light | 50gp | +3
+    - Chain Shirt | Light | 100gp | +4
+    - Hide | Medium | 30gp | +3
+    - Scale Mail | Medium | 75gp | +4
+    - Chainmail | Medium | 150gp | +5
+    - Breastplate | Medium | 250gp | +6
+    - Splint Mail | Heavy | 100gp | +5
+    - Banded Mail | Heavy | 200gp | +6
+    - Half-plate | Heavy | 600gp | +7
+    - Full Plate | Heavy | 1,500gp | +8
 
 ---
 id: shields
-columns: 2
+columns: 3
 header:
-    - Armor | Cost | Bonus | Weight
-    - :---- | :--- | :---- | :-----
+    - "**Armor** | Cost | Bonus"
+    - :---- | :--- | :----
 data:
-    - Buckler | 5gp | +1 | 5 lbs.
-    - Klar (1d4 damage) | 20gp | +1 | 6 lbs.
-    - Shield, light wooden | 10gp | +1 | 5 lbs.
-    - Shield, light steel | 5gp | +1 | 6 lbs.
-    - Shield, medium wooden | 35gp | +2 | 7 lbs.
-    - Shield, medium steel | 25gp | +2 | 10 lbs.
-    - Shield, heavy wooden | 85gp | +3 | 10 lbs.
-    - Shield, heavy steel | 75gp | +3 | 15 lbs.
-    - Shield, tower | 100gp | +4 | 25 lbs.
-    - Shield, kite | 150gp | +5 | 35 lbs.
-    - Shield, Mithral | 450gp | +6 | 45 lbs.
-    - Shield, Adamantine | 1,500gp | +7 | 25 lbs.
+    - Buckler | 5gp | +1
+    - Klar (1d4 damage) | 20gp | +1
+    - Shield, light wooden | 10gp | +1
+    - Shield, light steel | 5gp | +1
+    - Shield, medium wooden | 35gp | +2
+    - Shield, medium steel | 25gp | +2
+    - Shield, heavy wooden | 85gp | +3
+    - Shield, heavy steel | 75gp | +3
+    - Shield, tower | 100gp | +4
+    - Shield, kite | 150gp | +5
+    - Shield, Mithral | 450gp | +6
+    - Shield, Adamantine | 1,500gp | +7

--- a/src/data/gear.yml
+++ b/src/data/gear.yml
@@ -2,93 +2,93 @@
 id: adventuring-gear
 columns: 3
 header:
-    - Goods | Cost | Weight
-    - :---- | :--- | :-----
+    - "**Goods** | Cost"
+    - :---- | :---
 data:
-    - Acid (flask) | 10gp | 1 lb.
-    - Antitoxin (vial) | 50gp | 1 lb.
-    - Artisan's Tools | 5gp | 5 lbs.
-    - Backpack (empty) | 2gp | 2 lbs.
-    - Barrel (empty) | 2gp | 30 lbs.
-    - Basket (empty) | 4sp | 1 lb.
-    - Bedroll | 1sp | 5 lb.
-    - Bell | 1gp | -
-    - Blanket, winter | 5sp | 3 lbs.
-    - Block and Tackle | 5gp | 5 lbs.
-    - Bottle, wine, glass (empty) | 2gp | -
-    - Bucket (empty) | 5sp | 2 lbs.
-    - Caltrops | 1gp | 2 lbs.
-    - Candle | 1cp | -
-    - Canvas (sq. yd.) | 1sp | 1 lb.
-    - Case, map or scroll | 1gp | 0.5 lbs.
-    - Chain (10 ft.) | 30gp | 2 lbs.
-    - Chalk, 1 piece | 1cp | -
-    - Chest (empty) | 2gp | 25 lbs.
-    - Craftsman's Tools | 5gp | 5 lbs.
-    - Crowbar | 2gp | 5 lbs.
-    - Disguise Kit | 50gp | 8 lbs.
-    - Firewood (per day) | 1cp | 20 lbs.
-    - Fishhook | 1sp | -
-    - Fishing net (25 sq. ft.) | 4gp | 5 lbs.
-    - Flask (empty) | 3cp | 1 lb.
-    - Flint & Steel | 1gp | -
-    - Grappling Hook | 1gp | 4 lbs.
-    - Hammer | 5sp | 2 lbs.
-    - Healer's Kit | 50gp | 1 lb.
-    - Holy Symbol, wooden | 1gp | -
-    - Holy Symbol, silver | 25gp | 1 lb.
-    - Holy Water (flask) | 25gp | 1 lb.
-    - Hourglass | 25gp | 1 lb.
-    - Ink (1 oz. Vial) | 8gp | -
-    - Ink pen | 1sp | -
-    - Jug, clay | 3cp | 9 lbs.
-    - Ladder, 10 ft. | 5cp | 20 lbs.
-    - Lamp, common | 1sp | 1 lb.
-    - Lantern, bulls eye | 12gp | 3 lbs.
-    - Lantern, hooded | 7gp | 2 lbs.
-    - Lock, simple | 20gp | 1 lb.
-    - Lock, average | 40gp | 1 lb.
-    - Lock, good | 80gp | 1 lb.
-    - Magnifying Glass | 100gp | -
-    - Manacles | 15gp | 2 lbs.
-    - Mirror, small steel | 10gp | 0.5 lbs.
-    - Mug/Tankard, clay | 2cp | 1 lb.
-    - Musical Instrument | 5gp | 3 lbs.
-    - Oil, pint flask | 1sp | 1 lb.
-    - Paper (sheet) | 4sp | -
-    - Parchment (sheet) | 2sp | -
-    - Pick, miner's | 3gp | 10 lbs.
-    - Pitcher, clay | 2cp | 5 lbs.
-    - Piton | 1sp | 0.5 lbs.
-    - Pole, 10 ft. | 2sp | 8 lbs.
-    - Pot, iron | 5sp | 10 lbs.
-    - Pouch, belt (empty) | 1gp | 0.5 lbs.
-    - Ram, portable | 10gp | 20 lbs.
-    - Rations, trail (per day) | 5sp | 1 lb.
-    - Rope, hempen (50 ft.) | 1gp | 10 lbs.
-    - Rope, silk (50 ft.) | 10gp | 5 lbs.
-    - Sack (empty) | 1sp | 0.5 lbs.
-    - Sealing Wax | 1gp | 1 lb.
-    - Sewing Needle | 5sp | -
-    - Signal Whistle | 8sp | -
-    - Signet Ring | 5gp | -
-    - Sledge | 1gp | 10 lbs.
-    - Soap (per lb.) | 5sp | 1 lb.
-    - Spade or Shovel | 2gp | 8 lb.
-    - Spellbook (blank) | 15gp | 3 lbs.
-    - Spyglass | 1,000gp | 1 lb.
-    - Tent | 10gp | 20 lbs.
-    - Thieves' Tools | 30gp | 1 lb.
-    - Torch | 1cp | 1 lb.
-    - Vial, ink or potion | 1gp | 0.1 lbs.
-    - Water skin | 1gp | 4 lbs.
-    - Whetstone | 2cp | 1 lb.
+    - Acid (flask) | 10gp
+    - Antitoxin (vial) | 50gp
+    - Artisan's Tools | 5gp
+    - Backpack (empty) | 2gp
+    - Barrel (empty) | 2gp
+    - Basket (empty) | 4sp
+    - Bedroll | 1sp
+    - Bell | 1gp
+    - Blanket, winter | 5sp
+    - Block and Tackle | 5gp
+    - Bottle, wine, glass (empty) | 2gp
+    - Bucket (empty) | 5sp
+    - Caltrops | 1gp
+    - Candle | 1cp
+    - Canvas (sq. yd.) | 1sp
+    - Case, map or scroll | 1gp
+    - Chain (10 ft.) | 30gp
+    - Chalk, 1 piece | 1cp
+    - Chest (empty) | 2gp
+    - Craftsman's Tools | 5gp
+    - Crowbar | 2gp
+    - Disguise Kit | 50gp
+    - Firewood (per day) | 1cp
+    - Fishhook | 1sp
+    - Fishing net (25 sq. ft.) | 4gp
+    - Flask (empty) | 3cp
+    - Flint & Steel | 1gp
+    - Grappling Hook | 1gp
+    - Hammer | 5sp
+    - Healer's Kit | 50gp
+    - Holy Symbol, wooden | 1gp
+    - Holy Symbol, silver | 25gp
+    - Holy Water (flask) | 25gp
+    - Hourglass | 25gp
+    - Ink (1 oz. Vial) | 8gp
+    - Ink pen | 1sp
+    - Jug, clay | 3cp
+    - Ladder, 10 ft. | 5cp
+    - Lamp, common | 1sp
+    - Lantern, bulls eye | 12gp
+    - Lantern, hooded | 7gp
+    - Lock, simple | 20gp
+    - Lock, average | 40gp
+    - Lock, good | 80gp
+    - Magnifying Glass | 100gp
+    - Manacles | 15gp
+    - Mirror, small steel | 10gp
+    - Mug/Tankard, clay | 2cp
+    - Musical Instrument | 5gp
+    - Oil, pint flask | 1sp
+    - Paper (sheet) | 4sp
+    - Parchment (sheet) | 2sp
+    - Pick, miner's | 3gp
+    - Pitcher, clay | 2cp
+    - Piton | 1sp
+    - Pole, 10 ft. | 2sp
+    - Pot, iron | 5sp
+    - Pouch, belt (empty) | 1gp
+    - Ram, portable | 10gp
+    - Rations, trail (per day) | 5sp
+    - Rope, hempen (50 ft.) | 1gp
+    - Rope, silk (50 ft.) | 10gp
+    - Sack (empty) | 1sp
+    - Sealing Wax | 1gp
+    - Sewing Needle | 5sp
+    - Signal Whistle | 8sp
+    - Signet Ring | 5gp
+    - Sledge | 1gp
+    - Soap (per lb.) | 5sp
+    - Spade or Shovel | 2gp
+    - Spellbook (blank) | 15gp
+    - Spyglass | 1,000gp
+    - Tent | 10gp
+    - Thieves' Tools | 30gp
+    - Torch | 1cp
+    - Vial, ink or potion | 1gp
+    - Water skin | 1gp
+    - Whetstone | 2cp
 
 ---
 id: clothing
-columns: 3
+columns: 4
 header:
-    - Goods | Cost
+    - "**Goods** | Cost"
     - :---- | :---
 data:
     - Artisan's Outfit | 1gp
@@ -108,7 +108,7 @@ data:
 id: mounts
 columns: 3
 header:
-    - Goods | Cost
+    - "**Goods** | Cost"
     - :---- | :---
 data:
     - Barding, medium creature | armor price x2

--- a/src/data/weapons.yml
+++ b/src/data/weapons.yml
@@ -2,96 +2,96 @@
 id: light
 columns: 2
 header:
-    - Weapon | Cost | Dmg. | Range | Complexity | Weight
-    - :--- | :--- | :--- | :--- | :--- | :---
+    - "**Weapon** | Cost | Dmg. | Range | Complexity"
+    - :--- | :--- | :--- | :--- | :---
 data:
-    - Unarmed | — | 1d2 | — | Simple | —
-    - Cestus | 5gp | 1d4 | — | Simple | 1 lb.
-    - Dagger | 2gp | 1d4 | 10 ft. | Simple | 1 lb.
-    - Mace, light | 5gp | 1d6 | — | Simple | 4 lbs.
-    - Sickle | 5gp | 1d6 | — | Simple | 2 lbs.
-    - Pick, light | 5gp | 1d4 | — | Complex | 3 lbs.
-    - Handaxe | 5gp | 1d4 | — | Complex | 3 lbs.
-    - Hook | 8gp | 1d6 | — | Complex | 2 lbs
-    - Sap | 8gp | 1d6 | — | Complex | 2 lbs
-    - Gladius | 8gp | 1d6 | — | Complex | 3 lbs
-    - Axe, throwing | 10gp | 1d6 | 10ft. | Complex | 2 lbs
-    - Hammer, light | 12gp | 1d6 | 20ft. | Complex | 2 lbs
+    - Unarmed | — | 1d2 | — | Simple
+    - Cestus | 5gp | 1d4 | — | Simple
+    - Dagger | 2gp | 1d4 | 10 ft. | Simple
+    - Mace, light | 5gp | 1d6 | — | Simple
+    - Sickle | 5gp | 1d6 | — | Simple
+    - Pick, light | 5gp | 1d4 | — | Complex
+    - Handaxe | 5gp | 1d4 | — | Complex
+    - Hook | 8gp | 1d6 | — | Complex
+    - Sap | 8gp | 1d6 | — | Complex
+    - Gladius | 8gp | 1d6 | — | Complex
+    - Axe, throwing | 10gp | 1d6 | 10ft. | Complex
+    - Hammer, light | 12gp | 1d6 | 20ft. | Complex
 
 ---
 id: ranged
 columns: 2
 header:
-    - Weapon | Cost | Dmg. | Range | Complexity | Weight
-    - :--- | :--- | :--- | :--- | :--- | :---
+    - "**Weapon** | Cost | Dmg. | Range | Complexity"
+    - :--- | :--- | :--- | :--- | :---
 data:
-    - Sling | 1gp | 1d4 | 40ft. | Simple | —
-    - Atlatl | 5gp | 1d6 | 60ft. | Simple | 2 lbs.
-    - Crossbow, light | 35gp | 1d8 | 80ft. | Simple | 4 lbs.
-    - Crossbow, medium | 50gp | 1d10 | 120ft. | Simple | 6 lbs.
-    - Crossbow, heavy | 85gp | 2d6 | 160ft. | Complex | 8 lbs.
-    - Crossbow, hand | 100gp | 1d4 | 30ft. | Complex | 2 lbs.
-    - Shortbow | 30gp | 1d6 | 60ft. | Complex | 2 lbs.
-    - Shortbow, composite | 55gp | 1d8 | 80ft. | Complex | 2 lbs.
-    - Longbow | 75gp | 1d10 | 100ft. | Complex | 3 lbs.
-    - Longbow, composite | 100gp | 2d6 | 120ft. | Complex | 3 lbs.
+    - Sling | 1gp | 1d4 | 40ft. | Simple
+    - Atlatl | 5gp | 1d6 | 60ft. | Simple
+    - Crossbow, light | 35gp | 1d8 | 80ft. | Simple
+    - Crossbow, medium | 50gp | 1d10 | 120ft. | Simple
+    - Crossbow, heavy | 85gp | 2d6 | 160ft. | Complex
+    - Crossbow, hand | 100gp | 1d4 | 30ft. | Complex
+    - Shortbow | 30gp | 1d6 | 60ft. | Complex
+    - Shortbow, composite | 55gp | 1d8 | 80ft. | Complex
+    - Longbow | 75gp | 1d10 | 100ft. | Complex
+    - Longbow, composite | 100gp | 2d6 | 120ft. | Complex
 
 
 ---
 id: thrown
 columns: 2
 header:
-    - Weapon | Cost | Dmg. | Range | Complexity | Weight
-    - :--- | :--- | :--- | :--- | :--- | :---
+    - "**Weapon** | Cost | Dmg. | Range | Complexity"
+    - :--- | :--- | :--- | :--- | :---
 data:
-    - Dart | 5sp | 1d4 | 20ft. | Simple | 0.5 lbs.
-    - Kunai | 2gp | 1d4 | 60ft. | Simple | 1 lb.
-    - Javelin | 10gp | 1d6 | 30ft. | Simple | 2 lbs.
-    - Net | 20gp | — | 10ft. | Complex | 6 lbs.
-    - Shuriken | 10gp | 1d6 | 30ft. | Complex | 0.25 lbs.
+    - Dart | 5sp | 1d4 | 20ft. | Simple
+    - Kunai | 2gp | 1d4 | 60ft. | Simple
+    - Javelin | 10gp | 1d6 | 30ft. | Simple
+    - Net | 20gp | — | 10ft. | Complex
+    - Shuriken | 10gp | 1d6 | 30ft. | Complex
 
 ---
 id: two-handed
 columns: 2
 header:
-    - Weapon | Cost | Dmg. | Range | Complexity | Weight
-    - :--- | :--- | :--- | :--- | :--- | :---
+    - "**Weapon** | Cost | Dmg. | Range | Complexity"
+    - :--- | :--- | :--- | :--- | :---
 data:
-    - Bayonet | 2gp | 1d4 | — | Simple | 1 lb.
-    - Quarterstaff | 3gp | 1d6 | — | Simple | 4 lbs.
-    - Longspear | 5gp | 1d8 | — | Simple | 9 lbs.
-    - Spear | 8gp | 1d8 | 20ft. | Simple | 6 lbs.
-    - Falchion | 25gp | 1d6 | — | Complex | 8 lbs.
-    - Flail, heavy | 30gp | 1d8 | — | Complex | 10 lbs.
-    - Glaive | 30gp | 1d8 | — | Complex | 10 lbs.
-    - Greatclub | 30gp | 1d8 | — | Complex | 8 lbs.
-    - Lance | 30gp | 1d8 | — | Complex | 10 lbs.
-    - Scythe | 35gp | 2d4 | — | Complex | 10 lbs.
-    - Chain, spiked | 35gp | 2d4 | — | Complex | 10 lbs.
-    - Guisarme | 35gp | 2d4 | — | Complex | 12 lbs.
-    - Greataxe | 40gp | 1d10 | — | Complex | 12 lbs.
-    - Halberd | 40gp | 1d10 | — | Complex | 12 lbs.
-    - Greatsword | 50gp | 2d6 | — | Complex | 8 lbs.
+    - Bayonet | 2gp | 1d4 | — | Simple
+    - Quarterstaff | 3gp | 1d6 | — | Simple
+    - Longspear | 5gp | 1d8 | — | Simple
+    - Spear | 8gp | 1d8 | 20ft. | Simple
+    - Falchion | 25gp | 1d6 | — | Complex
+    - Flail, heavy | 30gp | 1d8 | — | Complex
+    - Glaive | 30gp | 1d8 | — | Complex
+    - Greatclub | 30gp | 1d8 | — | Complex
+    - Lance | 30gp | 1d8 | — | Complex
+    - Scythe | 35gp | 2d4 | — | Complex
+    - Chain, spiked | 35gp | 2d4 | — | Complex
+    - Guisarme | 35gp | 2d4 | — | Complex
+    - Greataxe | 40gp | 1d10 | — | Complex
+    - Halberd | 40gp | 1d10 | — | Complex
+    - Greatsword | 50gp | 2d6 | — | Complex
 
 ---
 id: one-handed
 columns: 2
 header:
-    - Weapon | Cost | Dmg. | Range | Complexity | Weight
-    - :--- | :--- | :--- | :--- | :--- | :---
+    - "**Weapon** | Cost | Dmg. | Range | Complexity"
+    - :--- | :--- | :--- | :--- | :---
 data:
-    - Club | 2gp | 1d6 | 10ft. | Simple | 3 lbs.
-    - Shortspear | 4gp | 1d6 | 20ft. | Simple | 3 lbs.
-    - Mace, heavy | 12gp | 1d8 | — | Simple | 8 lbs.
-    - Morningstar | 12gp | 1d8 | — | Simple | 6 lbs.
-    - Whip | 1gp | 1d3 | — | Complex | 2 lbs.
-    - Pick, heavy | 15gp | 1d6 | — | Complex | 6 lbs.
-    - Rapier | 15gp | 1d6 | — | Complex | 2 lbs.
-    - Scimitar | 15gp | 1d6 | — | Complex | 4 lbs.
-    - Warhammer | 20gp | 1d8 | — | Complex | 5 lbs.
-    - Battleaxe | 20gp | 1d8 | — | Complex | 6 lbs.
-    - Flail | 20gp | 1d8 | — | Complex | 5 lbs.
-    - Longsword | 20gp | 1d8 | — | Complex | 4 lbs.
-    - Trident | 25gp | 1d8 | 10ft. | Complex | 4 lbs.
-    - Waraxe | 35gp | 1d10 | — | Complex | 8 lbs.
-    - Sword, bastard | 35gp | 1d10 | — | Complex | 6 lbs.
+    - Club | 2gp | 1d6 | 10ft. | Simple
+    - Shortspear | 4gp | 1d6 | 20ft. | Simple
+    - Mace, heavy | 12gp | 1d8 | — | Simple
+    - Morningstar | 12gp | 1d8 | — | Simple
+    - Whip | 1gp | 1d3 | — | Complex
+    - Pick, heavy | 15gp | 1d6 | — | Complex
+    - Rapier | 15gp | 1d6 | — | Complex
+    - Scimitar | 15gp | 1d6 | — | Complex
+    - Warhammer | 20gp | 1d8 | — | Complex
+    - Battleaxe | 20gp | 1d8 | — | Complex
+    - Flail | 20gp | 1d8 | — | Complex
+    - Longsword | 20gp | 1d8 | — | Complex
+    - Trident | 25gp | 1d8 | 10ft. | Complex
+    - Waraxe | 35gp | 1d10 | — | Complex
+    - Sword, bastard | 35gp | 1d10 | — | Complex

--- a/src/markdown/microluxe20_equipment.md
+++ b/src/markdown/microluxe20_equipment.md
@@ -4,7 +4,7 @@
 
 When you create a character, you start with nothing but the clothes on your back and some gold in your pocket. Depending upon the setting and adventure your Gamemaster is running, you may have the opportunity to purchase some items before beginning play, or the Gamemaster may allow you to do your shopping in the game world.
 
-These tables list a number of items, their stats, and prices for Gamemasters to populate their shops and worlds and loot tables. The availabilty of items in these tables is at the Gamemaster's discretion – just because it's on the list doesn't mean you can buy it at just any shop in the world.
+These tables list a number of items, their stats, and prices for Gamemasters to populate their shops and worlds and loot tables. The availability of items in these tables is at the Gamemaster's discretion – just because it's on the list doesn't mean you can buy it at just any shop in the world.
 
 ## Starting Wealth
 
@@ -47,6 +47,8 @@ Here is the format for weapon entries (given as column headings on the table bel
 
 <!-- $data weapons.yml ranged -->
 
+<!-- $page-break -->
+
 ## Armor & Shields
 
 Here is the format for armor entries (given as column headings on the table below):
@@ -61,7 +63,7 @@ Here is the format for armor entries (given as column headings on the table belo
 
 ### Shields
 
-<!-- $data armor.yml shields -->
+<!-- $data armor.yml shields t-full -->
 
 ## Adventuring Equipment
 
@@ -71,13 +73,13 @@ Characters may purchase equipment from the following lists with their starting m
 
 Characters start with some clothing, usually Traveler's clothes. Clothing is not a replacement for armor, nor is armor a replacement for clothing.
 
-<!-- $data gear.yml clothing -->
+<!-- $data gear.yml clothing t-full -->
 
 <!-- $page-break -->
 
 ### Adventuring Gear
 
-<!-- $data gear.yml adventuring-gear -->
+<!-- $data gear.yml adventuring-gear t-full -->
 
 <!-- $page-break -->
 


### PR DESCRIPTION
Closes #43.

Removed weight listings from all tables, and bolds the first column heading to enable better recognition of where items start and end.